### PR TITLE
fix: Spectre CLI ExecuteAsync access modifier

### DIFF
--- a/src/aws-cur-anonymize/Cli/Commands.cs
+++ b/src/aws-cur-anonymize/Cli/Commands.cs
@@ -32,7 +32,7 @@ public class RunSettings : CommandSettings
 
 public class RunCommand : AsyncCommand<RunSettings>
 {
-    public override async Task<int> ExecuteAsync(CommandContext context, RunSettings settings, CancellationToken cancellationToken)
+    protected override async Task<int> ExecuteAsync(CommandContext context, RunSettings settings, CancellationToken cancellationToken)
     {
         // Show banner
         ShowBanner();


### PR DESCRIPTION
This fixes the build break currently affecting Dependabot PR #24.\n\n is now inherited as a protected member, so the override in  must be  instead of .\n\nAfter this merges, Dependabot PR #24 should rebase/update cleanly.